### PR TITLE
harden: sanitize child_process call in fix-ffmpeg-win.js...

### DIFF
--- a/scripts/fix-ffmpeg-win.js
+++ b/scripts/fix-ffmpeg-win.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { spawnSync } = require('child_process');
 
 exports.default = async function (context) {
     const platform = context.electronPlatformName;
@@ -25,8 +25,8 @@ exports.default = async function (context) {
         for (const bin of binaries) {
             if (fs.existsSync(bin)) {
                 try {
-                    execSync(`xattr -cr "${bin}"`);
-                    execSync(`chmod +x "${bin}"`);
+                    spawnSync('xattr', ['-cr', bin], { stdio: 'inherit' });
+                    spawnSync('chmod', ['+x', bin], { stdio: 'inherit' });
                     console.log(`Fixed permissions: ${path.basename(bin)}`);
                 } catch (err) {
                     console.warn(`Warning: could not fix ${path.basename(bin)}: ${err.message}`);


### PR DESCRIPTION
## Summary
Harden input handling in `scripts/fix-ffmpeg-win.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `scripts/fix-ffmpeg-win.js:28` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `context`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `scripts/fix-ffmpeg-win.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
