### PR TITLE
post-process progress, chapter split cleanup, and queue fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@
 .DS_Store
 *.pem
 
+# stray media downloads from dev testing (yt-dlp outputs at repo root)
+/*.ogg
+/*.m4a
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/package.json
+++ b/package.json
@@ -97,5 +97,9 @@
     "devDependencies": {
         "electron": "^33.0.0",
         "electron-builder": "^25.0.0"
+    },
+    "allowScripts": {
+        "electron@33.4.11": true,
+        "ffmpeg-static@5.3.0": true
     }
 }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -377,7 +377,7 @@ ipcMain.handle('playlist:detect', (_e, url) => {
 // Queue
 
 ipcMain.handle('queue:add', (_e, items) => {
-    log('Queue: adding', items.length, 'items');
+    log('Queue: adding', items.length, `item${items.length !== 1 ? 's' : ''}`);
     return queue.add(items);
 });
 
@@ -406,11 +406,6 @@ ipcMain.handle('queue:retry', (_e, itemId) => {
 
 ipcMain.handle('queue:retryFailed', () => {
     queue.retryFailed();
-    return { ok: true };
-});
-
-ipcMain.handle('queue:clearCompleted', () => {
-    queue.clearCompleted();
     return { ok: true };
 });
 

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -49,7 +49,6 @@ contextBridge.exposeInMainWorld('api', {
     queueCancelAll: () => ipcRenderer.invoke('queue:cancelAll'),
     queueRetry: (itemId) => ipcRenderer.invoke('queue:retry', itemId),
     queueRetryFailed: () => ipcRenderer.invoke('queue:retryFailed'),
-    queueClearCompleted: () => ipcRenderer.invoke('queue:clearCompleted'),
     queueRemove: (itemId) => ipcRenderer.invoke('queue:remove', itemId),
 
     onLog: (cb) => {

--- a/src/main/queue.js
+++ b/src/main/queue.js
@@ -20,6 +20,8 @@ class DownloadQueue {
         this._callbacks = null; // onProgress, onLog, onItemUpdate, onQueueUpdate
         this._currentProc = null; // ref to kill on cancel
         this._idCounter = 0;
+        this._completedRun = 0; // completed/failed since processing started
+        this._failedRun = 0;
         this._downloadPath = null;
         this._videoCodec = 'auto';
     }
@@ -52,7 +54,10 @@ class DownloadQueue {
                 formatId: item.formatId,
                 extractAudio: item.extractAudio || false,
                 audioFormat: item.audioFormat || 'mp3',
+                embedChapters: item.embedChapters || false,
+                splitChapters: item.splitChapters || false,
                 videoCodec: item.videoCodec || this._videoCodec || 'auto',
+                duration: item.duration || null,
                 state: STATE.PENDING,
                 error: null,
                 progress: null, // { percent, speed, eta }
@@ -140,13 +145,6 @@ class DownloadQueue {
         }
     }
 
-    clearCompleted() {
-        this._items = this._items.filter((i) => i.state === STATE.PENDING || i.state === STATE.DOWNLOADING);
-        // Reset id counter if queue is empty
-        if (this._items.length === 0) this._idCounter = 0;
-        this._emitQueueUpdate();
-    }
-
     remove(itemId) {
         const item = this._items.find((i) => i.id === itemId);
         if (!item) return;
@@ -199,29 +197,40 @@ class DownloadQueue {
             log('Queue: all done');
             this._emit('log', 'Queue complete');
             this._emitQueueUpdate();
+            this._completedRun = 0;
+            this._failedRun = 0;
             return;
         }
 
         this._isProcessing = true;
         nextItem.state = STATE.DOWNLOADING;
-        nextItem.progress = { percent: '0%', speed: '', eta: '' };
+        nextItem.progress = { percent: '0%', speed: '', eta: '', phase: 'download', ppStep: '' };
         this._emitItemUpdate(nextItem);
         this._emitQueueUpdate();
 
+        // Completed items leave the queue and failed items stay put, so the list
+        // alone is not a reliable total. Derive the batch size from the run
+        // counters plus whatever is still pending/downloading.
         const counts = this.counts;
-        const position = counts.completed + counts.failed + 1;
-        const total = counts.total;
+        const total = this._completedRun + this._failedRun + counts.pending + counts.downloading;
+        const position = this._completedRun + this._failedRun + 1;
         this._emit('log', `Downloading ${position}/${total}: ${nextItem.title}`);
 
         try {
             this._cancelled = false;
             await this._downloadOne(nextItem);
             nextItem.state = STATE.COMPLETED;
-            nextItem.progress = { percent: '100%', speed: '', eta: '' };
+            nextItem.progress = { percent: '100%', speed: '', eta: '', phase: 'done', ppStep: '' };
+            this._completedRun++;
             this._emit('log', `Completed: ${nextItem.title} ✓`);
             log('Queue: completed', nextItem.title);
             this._emitItemComplete(nextItem);
+
+            // Completed downloads leave the queue right away; history keeps
+            // them instead, so the list only shows what is still to do.
+            this._items = this._items.filter((i) => i.id !== nextItem.id);
         } catch (err) {
+            this._failedRun++;
             if (this._cancelled) {
                 nextItem.state = STATE.FAILED;
                 nextItem.error = 'Cancelled';
@@ -237,7 +246,9 @@ class DownloadQueue {
         }
 
         this._currentProc = null;
-        this._emitItemUpdate(nextItem);
+        if (this._items.includes(nextItem)) {
+            this._emitItemUpdate(nextItem);
+        }
         this._emitQueueUpdate();
 
         // Continue to next, always, even after failure
@@ -265,6 +276,9 @@ class DownloadQueue {
             onLog: (msg) => {
                 this._emit('log', msg);
             },
+            onSpawn: (proc) => {
+                this._currentProc = proc;
+            },
         };
 
         const downloadPromise = ytdlp.download(
@@ -275,20 +289,14 @@ class DownloadQueue {
                 extractAudio: item.extractAudio,
                 audioFormat: item.audioFormat,
                 videoCodec: item.videoCodec,
+                embedChapters: item.embedChapters,
+                splitChapters: item.splitChapters,
+                duration: item.duration,
             },
             callbacks,
         );
 
-        this._currentProc = callbacks._proc;
-
-        const pollInterval = setInterval(() => {
-            if (callbacks._proc) {
-                this._currentProc = callbacks._proc;
-                clearInterval(pollInterval);
-            }
-        }, 50);
-
-        return downloadPromise.finally(() => clearInterval(pollInterval));
+        return downloadPromise;
     }
 
     _emit(type, data) {
@@ -316,6 +324,8 @@ class DownloadQueue {
                 items: this.getAll(),
                 counts: this.counts,
                 isActive: this.isActive,
+                completedRun: this._completedRun,
+                failedRun: this._failedRun,
             });
         }
     }

--- a/src/main/ytdlp.js
+++ b/src/main/ytdlp.js
@@ -4,6 +4,7 @@
 const { spawn, execFile } = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const { log, logError } = require('./utils');
 const cookies = require('./cookies');
 
@@ -31,6 +32,65 @@ const VIDEO_CODEC_LABELS = {
     vp9: 'VP9',
     av1: 'AV1',
 };
+
+// Post-processor lines tell us what yt-dlp is doing after the download hits
+// 100%. During these stages yt-dlp prints no progress lines at all, so without
+// tracking them the progress bar freezes on the last "100% - ETA NA" line.
+const PP_STEPS = {
+    '[Merger]': 'Merging streams',
+    '[ExtractAudio]': 'Extracting audio',
+    '[VideoConvertor]': 'Converting video',
+    '[VideoRemuxer]': 'Remuxing video',
+    '[EmbedChapters]': 'Embedding chapters',
+    '[SplitChapters]': 'Splitting chapters',
+    '[Metadata]': 'Adding metadata',
+    '[EmbedThumbnail]': 'Embedding thumbnail',
+    '[ThumbnailsConvertor]': 'Converting thumbnail',
+};
+
+// Map a yt-dlp output line to a friendly processing step, or null if it is not
+// a post-processor line.
+function postProcessStep(trimmed) {
+    if (!trimmed || !trimmed.startsWith('[')) return null;
+    for (const [prefix, step] of Object.entries(PP_STEPS)) {
+        if (trimmed.startsWith(prefix)) return step;
+    }
+    if (trimmed.startsWith('[Fixup')) return 'Polishing file';
+    return null;
+}
+
+// Steps where ffmpeg actually re-encodes audio/video, so the -progress file
+// tracks real time. Embedding/splitting chapters are fast remuxes that each
+// restart ffmpeg and would make the percentage jump backwards.
+const ENCODE_STEPS = new Set(['Merging streams', 'Extracting audio', 'Converting video']);
+
+// Extract a full file path from a post-processor destination line. yt-dlp uses
+// either "Destination: <path>" or "Merging formats into \"<path>\"".
+function postProcessPath(trimmed) {
+    let m = trimmed.match(/Destination: "?(.+?)"?\s*$/);
+    if (!m) m = trimmed.match(/Merging formats into "(.+)"\s*$/);
+    return m ? m[1].trim() : null;
+}
+
+// yt-dlp reports speed as "Unknown B/s" and ETA as "NA"/"Unknown" when it
+// cannot tell. Strip those before the value reaches the UI or log, and round
+// the numbers so the progress line stays short.
+function cleanReportedSpeed(s) {
+    if (!s) return '';
+    const t = String(s).trim();
+    if (!t || /unknown|na/i.test(t)) return '';
+    const m = t.match(/^([\d.]+)(.*)$/);
+    if (!m) return t;
+    const n = parseFloat(m[1]);
+    return (Number.isFinite(n) ? String(Math.round(n)) : m[1]) + m[2];
+}
+
+function cleanReportedEta(e) {
+    if (!e) return '';
+    const t = String(e).trim();
+    if (!t || /unknown|na/i.test(t)) return '';
+    return t;
+}
 
 // Does a yt-dlp vcodec string belong to the requested codec family?
 function matchesVideoCodec(vcodec, codec) {
@@ -358,6 +418,7 @@ function cleanInfo(raw) {
         age_limit: raw.age_limit || 0,
         live_status: raw.live_status || 'not_live',
         formats,
+        chapters: raw.chapters || [],
         _fetched_at: Date.now(),
     };
 }
@@ -473,11 +534,32 @@ function buildPresets(formats, videoCodec = 'auto') {
         audioFormat: 'm4a',
     });
 
+    presets.push({
+        id: 'audio-ogg',
+        label: 'OGG',
+        tag: '',
+        size: formatBytes(audioSize((f) => f.acodec?.includes('vorbis') || f.acodec?.includes('opus'))),
+        formatId: 'ba[acodec*=vorbis]/ba[acodec*=opus]/ba/b',
+        type: 'audio',
+        // yt-dlp calls the ogg container format "vorbis"
+        audioFormat: 'vorbis',
+    });
+
+    presets.push({
+        id: 'audio-wav',
+        label: 'WAV',
+        tag: '',
+        size: formatBytes(audioSize(() => true)),
+        formatId: 'ba/b',
+        type: 'audio',
+        audioFormat: 'wav',
+    });
+
     return presets;
 }
 
-async function download({ url, formatId, outputDir, extractAudio, audioFormat, videoCodec }, callbacks) {
-    const { onProgress, onLog } = callbacks;
+async function download({ url, formatId, outputDir, extractAudio, audioFormat, videoCodec, embedChapters, splitChapters, duration }, callbacks) {
+    const { onProgress, onLog, onSpawn } = callbacks;
 
     const ytdlp = getYtdlpPath();
     if (!ytdlp) throw new Error('yt-dlp not found');
@@ -492,7 +574,7 @@ async function download({ url, formatId, outputDir, extractAudio, audioFormat, v
         '--socket-timeout',
         '30',
         '--progress-template',
-        'download:DLPROG %(progress._percent_str)s %(progress._speed_str)s %(progress._eta_str)s',
+        'download:DLPROG %(progress._percent_str)s|%(progress._speed_str)s|%(progress._eta_str)s',
         '-o',
         path.join(outputDir, '%(title)s [%(id)s].%(ext)s'),
     ];
@@ -502,8 +584,16 @@ async function download({ url, formatId, outputDir, extractAudio, audioFormat, v
         args.push('--ffmpeg-location', path.dirname(ffmpeg));
     }
 
+    // yt-dlp gives no percentage during post-processing, so we cheat: point
+    // ffmpeg's -progress at a temp file and track out_time ourselves. The
+    // renderer then shows a real percentage instead of an indeterminate bar.
+    // yt-dlp's arg splitter chokes on backslash paths, so use forward slashes.
+    const ppFile = path.join(os.tmpdir(), `arcdlp-pp-${process.pid}-${Date.now()}.txt`).replace(/\\/g, '/');
+    const ppArgs = ['-progress', ppFile];
+
     if (extractAudio) {
         args.push('-x', '--audio-format', audioFormat || 'mp3', '--audio-quality', '0');
+        args.push('--postprocessor-args', 'ffmpeg:' + ppArgs.join(' '));
     } else if (formatId) {
         const codec = videoCodec && VIDEO_CODEC_SORT[videoCodec] ? videoCodec : null;
         const container = codec ? VIDEO_CODEC_CONTAINER[codec] : 'mp4';
@@ -524,10 +614,29 @@ async function download({ url, formatId, outputDir, extractAudio, audioFormat, v
             // Re-encode audio to AAC for universal playback.
             // YouTube serves Opus audio which Windows Media Player can't decode in MP4.
             // AAC is fast to encode and works on every player on every OS.
-            args.push('--postprocessor-args', 'ffmpeg:-c:v copy -c:a aac');
+            ppArgs.push('-c:v copy', '-c:a aac');
+            args.push('--postprocessor-args', 'ffmpeg:' + ppArgs.join(' '));
+        } else {
+            // WebM takes yt-dlp's default straight copy merge. AAC is not valid in
+            // WebM, and the format sort above already biases audio to Opus.
+            args.push('--postprocessor-args', 'ffmpeg:' + ppArgs.join(' '));
         }
-        // WebM takes yt-dlp's default straight copy merge. AAC is not valid in
-        // WebM, and the format sort above already biases audio to Opus.
+    }
+
+    // Chapter handling. Embedding adds chapter markers to the file, splitting
+    // writes each chapter as its own file. Split already implies embed, so we
+    // only pass one flag. Both need ffmpeg to remux.
+    if (splitChapters || embedChapters) {
+        const hasFfmpeg = ffmpeg && ffmpeg !== 'ffmpeg';
+        if (hasFfmpeg) {
+            if (splitChapters) {
+                args.push('--split-chapters');
+            } else {
+                args.push('--embed-chapters');
+            }
+        } else {
+            onLog('Chapter options need ffmpeg, skipping them for this download.');
+        }
     }
 
     await appendCookieArgs(args, url);
@@ -535,7 +644,58 @@ async function download({ url, formatId, outputDir, extractAudio, audioFormat, v
     log('Download args:', args.join(' '));
 
     return new Promise((resolve, reject) => {
-        const proc = spawn(ytdlp, args, { env: getSpawnEnv() });
+        // cwd matters: --split-chapters writes chapter files relative to the
+        // working directory, not the -o path. Without this they'd end up in
+        // the app folder instead of the chosen download folder.
+        const proc = spawn(ytdlp, args, { env: getSpawnEnv(), cwd: outputDir });
+
+        // Active download state. Progress lines update it, and post-processor
+        // lines switch the phase so the UI can show what is happening.
+        const state = { percent: '0%', percentNum: 0, speed: '', eta: '', phase: 'download', ppStep: '', encodePct: null };
+        // When --split-chapters runs, yt-dlp keeps the whole file as a
+        // "non-destructive" leftover. Track the full-file path so we can
+        // delete it after the chapter files are written.
+        let mainOutputFile = null;
+        let splitProducedChapters = false;
+
+        function emitProgress() {
+            onProgress({ ...state });
+        }
+
+        // Real post-process percentage. yt-dlp prints no numbers, so track the
+        // ffmpeg -progress file we injected: out_time vs the media duration.
+        let ppTimer = null;
+        function startPpPolling() {
+            if (ppTimer || !duration) return;
+            ppTimer = setInterval(() => {
+                try {
+                    if (state.phase !== 'processing' || !ENCODE_STEPS.has(state.ppStep)) return;
+                    const txt = fs.readFileSync(ppFile, 'utf8');
+                    const m = txt.match(/out_time_us=(\d+)/g);
+                    if (!m) return;
+                    const lastUs = parseInt(m[m.length - 1].split('=')[1], 10) || 0;
+                    const totalUs = duration * 1000000;
+                    const pct = lastUs > 0 ? Math.min(100, (lastUs / totalUs) * 100) : 0;
+                    if (Math.abs(pct - (state.encodePct || 0)) >= 1) {
+                        state.encodePct = Math.round(pct);
+                        emitProgress();
+                    }
+                } catch {
+                    // File not ready yet; keep polling
+                }
+            }, 500);
+        }
+        function stopPpPolling() {
+            if (ppTimer) {
+                clearInterval(ppTimer);
+                ppTimer = null;
+            }
+            try {
+                fs.unlinkSync(ppFile);
+            } catch {
+                /* */
+            }
+        }
 
         // Parse progress from both stdout and stderr
         function parseOutput(data) {
@@ -543,26 +703,56 @@ async function download({ url, formatId, outputDir, extractAudio, audioFormat, v
             const lines = text.split('\n');
             for (const line of lines) {
                 if (line.startsWith('DLPROG ')) {
-                    const parts = line.slice(7).trim().split(/\s+/);
-                    const percent = (parts[0] || '0%').trim();
-                    const speed = (parts[1] || '').trim();
-                    const eta = (parts[2] || '').trim();
-                    log('Progress:', percent, speed, eta);
-                    onProgress({ percent, speed, eta });
+                    // Pipe-separated fields: speed values can contain spaces
+                    // ("Unknown B/s"), so whitespace splitting shifts columns.
+                    const parts = line.slice(7).trim().split('|');
+                    state.percent = (parts[0] || '0%').trim();
+                    state.percentNum = parseFloat(state.percent) || 0;
+                    state.speed = cleanReportedSpeed((parts[1] || '').trim());
+                    state.eta = cleanReportedEta((parts[2] || '').trim());
+                    state.phase = 'download';
+                    state.ppStep = '';
+                    log('Progress:', Math.round(state.percentNum) + '%', state.speed || '-', state.eta || '-');
+                    emitProgress();
                     continue;
                 }
 
                 const trimmed = line.trim();
-                if (trimmed && !trimmed.startsWith('WARNING')) {
-                    if (
-                        trimmed.startsWith('[download]') ||
-                        trimmed.startsWith('[Merger]') ||
-                        trimmed.startsWith('[ExtractAudio]') ||
-                        trimmed.startsWith('[info]') ||
-                        trimmed.startsWith('Deleting')
-                    ) {
-                        onLog(trimmed);
+                if (!trimmed || trimmed.startsWith('WARNING')) continue;
+
+                const step = postProcessStep(trimmed);
+                if (step || trimmed.startsWith('Deleting')) {
+                    // Only claim the encoding phase once the file is actually
+                    // downloaded, so unrelated [Merger]/[info] noise during
+                    // early progress is never mistaken for post-processing.
+                    if (step && state.percentNum >= 100) {
+                        state.phase = 'processing';
+                        state.ppStep = step;
+                        if (ENCODE_STEPS.has(step)) {
+                            startPpPolling();
+                        } else {
+                            // Remux/embed/split are instant; clear the encode
+                            // fill so the UI falls back to an indeterminate bar.
+                            state.encodePct = null;
+                        }
+                    } else if (trimmed.startsWith('Deleting')) {
+                        state.phase = 'cleanup';
+                        state.ppStep = '';
                     }
+                    if (trimmed.startsWith('[SplitChapters] Chapter') && !trimmed.includes('unavailable')) {
+                        splitProducedChapters = true;
+                    } else {
+                        const dest = postProcessPath(trimmed);
+                        if (dest) mainOutputFile = dest;
+                    }
+
+                    onLog(trimmed);
+                    emitProgress();
+                    continue;
+                }
+
+                if (trimmed.startsWith('[download]') || trimmed.startsWith('[info]')) {
+                    onLog(trimmed);
                 }
             }
         }
@@ -576,6 +766,7 @@ async function download({ url, formatId, outputDir, extractAudio, audioFormat, v
         });
 
         proc.on('close', (code) => {
+            stopPpPolling();
             if (code !== 0) {
                 const msg = stderrBuf.trim() || `yt-dlp exited with code ${code}`;
                 logError('Download failed:', msg);
@@ -584,15 +775,29 @@ async function download({ url, formatId, outputDir, extractAudio, audioFormat, v
             }
             log('Download completed');
             onLog('Download complete ✓');
+            if (splitProducedChapters && mainOutputFile) {
+                // --split-chapters is non-destructive: yt-dlp leaves the full
+                // file next to the chapter files. The user asked for chapters,
+                // so drop the redundant copy now that the split succeeded.
+                try {
+                    fs.unlinkSync(mainOutputFile);
+                    log('Removed full file after chapter split:', mainOutputFile);
+                } catch (e) {
+                    log('Could not remove full file after split:', e.message);
+                }
+            }
             resolve({ ok: true });
         });
 
         proc.on('error', (err) => {
+            // Spawn failed before any output; no 'close' will fire, so clean up
+            // the interval and the temp progress file here as well.
+            stopPpPolling();
             logError('Download spawn error:', err.message);
             reject(new Error(`Cannot run yt-dlp: ${err.message}`));
         });
 
-        callbacks._proc = proc;
+        if (onSpawn) onSpawn(proc);
     });
 }
 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -584,6 +584,80 @@ button {
     margin: 12px 0;
 }
 
+/* Chapter Options */
+
+.chapter-options {
+    margin-bottom: 16px;
+}
+
+.options-row {
+    display: flex;
+    gap: 24px;
+    margin-bottom: 10px;
+}
+
+.options-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    user-select: none;
+    position: relative;
+}
+
+.options-item input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.options-check {
+    width: 18px;
+    height: 18px;
+    border: 2px solid var(--text-3);
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.15s;
+    flex-shrink: 0;
+}
+
+.options-item:hover .options-check {
+    border-color: var(--accent);
+}
+
+.options-item input:checked + .options-check {
+    background: var(--accent);
+    border-color: var(--accent);
+}
+
+.options-item input:checked + .options-check::after {
+    content: "✓";
+    color: white;
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.options-item input:disabled + .options-check {
+    opacity: 0.4;
+    border-color: var(--text-3);
+    background: var(--text-3);
+}
+
+.options-label {
+    color: var(--text);
+}
+
+.options-hint {
+    font-size: 12px;
+    color: var(--text-3);
+    line-height: 1.5;
+}
+
 /* Empty State */
 
 .empty-state {
@@ -1283,13 +1357,6 @@ button {
     border-color: var(--accent);
 }
 
-.pl-format-note {
-    font-size: 12px;
-    color: var(--text-3);
-    font-style: italic;
-    margin-top: -4px;
-}
-
 /* Queue Tab */
 
 .queue-toolbar {
@@ -1473,15 +1540,42 @@ button {
     transition: width 0.4s ease;
 }
 
+/* Post-processing (merge/encode) shows an indeterminate striped bar. */
+.q-item-progress-fill.full {
+    width: 100% !important;
+    transition: none;
+}
+
+.q-item-progress-fill.striped {
+    background-image: linear-gradient(
+        45deg,
+        rgba(255, 255, 255, 0.25) 25%,
+        transparent 25%,
+        transparent 50%,
+        rgba(255, 255, 255, 0.25) 50%,
+        rgba(255, 255, 255, 0.25) 75%,
+        transparent 75%,
+        transparent
+    );
+    background-size: 24px 24px;
+    animation: qStripes 0.9s linear infinite;
+}
+
+@keyframes qStripes {
+    from {
+        background-position: 0 0;
+    }
+
+    to {
+        background-position: 24px 0;
+    }
+}
+
 /* Queue state styling */
 
 .q-state-downloading {
     border-color: rgba(0, 122, 255, 0.25);
     background: var(--accent-soft);
-}
-
-.q-state-completed {
-    opacity: 0.65;
 }
 
 .q-state-failed {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -89,6 +89,26 @@
                             <div class="section-label">Extract audio</div>
                             <div id="audioFormats" class="format-list"></div>
 
+                            <hr class="sep" />
+
+                            <div id="chapterOptions" class="chapter-options" style="display: none">
+                                <div class="section-label">Options</div>
+                                <div class="options-row">
+                                    <label class="options-item">
+                                        <input type="checkbox" id="optEmbedChapters" />
+                                        <span class="options-check"></span>
+                                        <span class="options-label">Embed chapters</span>
+                                    </label>
+                                    <label class="options-item">
+                                        <input type="checkbox" id="optSplitChapters" />
+                                        <span class="options-check"></span>
+                                        <span class="options-label">Split into chapter files</span>
+                                    </label>
+                                </div>
+                                <div class="options-hint">Requires a video with chapters. Split saves each chapter as
+                                    its own file. Applies to video and audio saves.</div>
+                            </div>
+
                             <button id="dlBtn" class="btn-download" onclick="doDownload()">
                                 Add to Queue
                             </button>
@@ -136,11 +156,30 @@
                                         <option value="ba/b" data-audio="true" data-format="opus">
                                             OPUS (audio only)
                                         </option>
+                                        <option value="ba/b" data-audio="true" data-format="vorbis">
+                                            OGG (audio only)
+                                        </option>
+                                        <option value="ba/b" data-audio="true" data-format="wav">
+                                            WAV (audio only)
+                                        </option>
                                     </select>
                                 </div>
-                                <div class="pl-format-note">If a video doesn't have the selected quality, the best
-                                    available
-                                    will be used.</div>
+                                <div id="plChapterOptions" class="chapter-options" style="display: none">
+                                    <div class="options-row">
+                                        <label class="options-item">
+                                            <input type="checkbox" id="plOptEmbedChapters" />
+                                            <span class="options-check"></span>
+                                            <span class="options-label">Embed chapters</span>
+                                        </label>
+                                        <label class="options-item">
+                                            <input type="checkbox" id="plOptSplitChapters" />
+                                            <span class="options-check"></span>
+                                            <span class="options-label">Split into chapter files</span>
+                                        </label>
+                                    </div>
+                                    <div class="options-hint">Applies to each selected item. Split saves every
+                                        chapter as its own file. Works for video and audio.</div>
+                                </div>
                                 <button id="plDownloadBtn" class="btn-download" onclick="doPlaylistDownload()">
                                     Add Selected to Queue
                                 </button>
@@ -180,9 +219,6 @@
                         </button>
                         <button id="qRetryFailedBtn" class="btn-sm" onclick="doRetryFailed()" style="display: none">
                             Retry failed
-                        </button>
-                        <button id="qClearDoneBtn" class="btn-sm" onclick="doClearCompleted()" style="display: none">
-                            Clear done
                         </button>
                         <button id="qCancelAllBtn" class="btn-sm btn-sm-danger" onclick="doCancelAll()"
                             style="display: none">

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -4,6 +4,9 @@ let selectedPreset = null;
 let isFetching = false;
 let historyCache = [];
 
+// Per-download chapter choices, cleared whenever a new video is shown.
+let selectedChapters = { embed: false, split: false };
+
 // Fetch queue - allows multiple URLs to be fetched without blocking
 let fetchQueue = [];
 let fetchQueueIdCounter = 0;
@@ -13,6 +16,9 @@ let activeFetchId = null;
 let playlistItems = [];
 let playlistSelected = new Set();
 let isPlaylistMode = false;
+
+// Chapter choices for playlist batch downloads.
+let playlistChapters = { embed: false, split: false };
 
 let queueData = {
     items: [],
@@ -46,6 +52,16 @@ const $dlBtn = $('dlBtn');
 const $logBody = $('logBody');
 const $toastContainer = $('toastContainer');
 
+// Chapter options
+const $chapterOptions = $('chapterOptions');
+const $optEmbed = $('optEmbedChapters');
+const $optSplit = $('optSplitChapters');
+
+// Playlist chapter options
+const $plChapterOptions = $('plChapterOptions');
+const $plOptEmbed = $('plOptEmbedChapters');
+const $plOptSplit = $('plOptSplitChapters');
+
 // Fetch panel
 const $fetchPanel = $('fetchPanel');
 const $fetchPanelItems = $('fetchPanelItems');
@@ -71,7 +87,6 @@ const $queueEmpty = $('queueEmpty');
 const $queueStatus = $('queueStatus');
 const $queueCount = $('queueCount');
 const $qRetryFailedBtn = $('qRetryFailedBtn');
-const $qClearDoneBtn = $('qClearDoneBtn');
 const $qCancelAllBtn = $('qCancelAllBtn');
 
 function switchTab(tabId) {
@@ -144,7 +159,7 @@ window.api.onLog((msg) => {
 window.api.onQueueUpdate((data) => {
     const wasActive = wasQueueActive;
     const isNowActive = data.isActive;
-    const hasCompleted = data.counts.completed > 0;
+    const ranJobs = data.completedRun > 0 || data.failedRun > 0;
 
     queueData = data;
     wasQueueActive = isNowActive;
@@ -152,13 +167,14 @@ window.api.onQueueUpdate((data) => {
     renderQueue();
     updateQueueCount();
 
-    // Show toast when queue finishes (was active, now idle, has completed items)
-    if (wasActive && !isNowActive && hasCompleted) {
-        const { completed, failed } = data.counts;
+    // Show toast when queue finishes (was active, now idle, items ran).
+    // Completed items auto-remove now, so the run counters carry the totals.
+    if (wasActive && !isNowActive && ranJobs) {
+        const { completedRun: done, failedRun: failed } = data;
         if (failed > 0) {
-            showToast(`Downloads complete: ${completed} done, ${failed} failed`);
+            showToast(`Downloads complete: ${done} done, ${failed} failed`);
         } else {
-            showToast(`${completed} download${completed !== 1 ? 's' : ''} complete ✓`, 'success');
+            showToast(`${done} download${done !== 1 ? 's' : ''} complete ✓`, 'success');
         }
     }
 });
@@ -391,6 +407,7 @@ function selectFetchItem(id) {
     videoInfo = item.info;
     presets = item.presets;
     selectedPreset = null;
+    selectedChapters = { embed: false, split: false };
     isPlaylistMode = false;
 
     hideError();
@@ -541,6 +558,7 @@ function doClear() {
     videoInfo = null;
     presets = [];
     selectedPreset = null;
+    selectedChapters = { embed: false, split: false };
     activeFetchId = null;
     $clearBtn.style.display = 'none';
     renderFetchPanel();
@@ -712,6 +730,29 @@ function formatNumber(n) {
     return n.toLocaleString();
 }
 
+// Progress text helpers. yt-dlp reports percent like "24.2%", speed like
+// "11.42MiB/s", and ETA "NA" or "00:00" when it cannot tell. Round numbers and
+// drop the meaningless bits so the queue line stays short and tidy.
+function roundValue(s) {
+    const m = String(s || '').match(/^([-+]?[\d.]+)(.*)$/);
+    if (!m) return s;
+    return String(Math.round(parseFloat(m[1]))) + m[2];
+}
+
+function cleanEta(eta) {
+    if (!eta) return '';
+    const t = String(eta).trim();
+    if (!t || /na|unknown/i.test(t) || t === '--:--' || t === '00:00') return '';
+    return t;
+}
+
+function cleanSpeed(speed) {
+    if (!speed) return '';
+    const t = String(speed).trim();
+    if (!t || /na|unknown/i.test(t)) return '';
+    return roundValue(t);
+}
+
 function formatDate(yyyymmdd) {
     if (!yyyymmdd || yyyymmdd.length !== 8) return yyyymmdd || '';
     try {
@@ -751,7 +792,52 @@ function selectFormat(id) {
     $card.querySelectorAll('.format-option').forEach((el) => {
         el.classList.toggle('selected', el.dataset.id === id);
     });
+    updateChapterOptions();
 }
+
+// Show the chapter checkboxes when the video has chapters, for video and audio
+// saves alike. Split implies embed, so the embed box is forced on and locked
+// while split is on.
+function updateChapterOptions() {
+    const hasChapters = Array.isArray(videoInfo?.chapters) && videoInfo.chapters.length > 0;
+    $chapterOptions.style.display = hasChapters ? '' : 'none';
+
+    $optEmbed.checked = selectedChapters.embed || selectedChapters.split;
+    $optEmbed.disabled = selectedChapters.split;
+    $optSplit.checked = selectedChapters.split;
+}
+
+$optEmbed.addEventListener('change', () => {
+    selectedChapters.embed = $optEmbed.checked;
+    updateChapterOptions();
+});
+
+$optSplit.addEventListener('change', () => {
+    selectedChapters.split = $optSplit.checked;
+    updateChapterOptions();
+});
+
+// Playlist chapter toggles. Same behavior as the single video options, and it
+// applies to video and audio saves alike.
+function updatePlChapterOptions() {
+    $plChapterOptions.style.display = '';
+
+    $plOptEmbed.checked = playlistChapters.embed || playlistChapters.split;
+    $plOptEmbed.disabled = playlistChapters.split;
+    $plOptSplit.checked = playlistChapters.split;
+}
+
+$plOptEmbed.addEventListener('change', () => {
+    playlistChapters.embed = $plOptEmbed.checked;
+    updatePlChapterOptions();
+});
+
+$plOptSplit.addEventListener('change', () => {
+    playlistChapters.split = $plOptSplit.checked;
+    updatePlChapterOptions();
+});
+
+$plFormatSelect.addEventListener('change', updatePlChapterOptions);
 
 function hideCard() {
     $card.classList.remove('visible');
@@ -775,6 +861,10 @@ async function doDownload() {
                 formatId: selectedPreset.formatId,
                 extractAudio: isAudio,
                 audioFormat: isAudio ? selectedPreset.audioFormat || 'mp3' : undefined,
+                duration: videoInfo.duration || null,
+                // OGG/vorbis and WAV don't support embedded chapters; only mp3/m4a/opus do.
+                embedChapters: selectedChapters.embed && !(isAudio && ['vorbis', 'wav'].includes(selectedPreset.audioFormat)),
+                splitChapters: selectedChapters.split,
             },
         ]);
 
@@ -828,11 +918,13 @@ function showPlaylist() {
     $empty.style.display = 'none';
     $card.classList.remove('visible');
     $plCard.classList.add('visible');
+    playlistChapters = { embed: false, split: false };
     $('plFooter').style.display = 'none'; // hidden until fetch completes
 }
 
 function showPlaylistFooter() {
     $('plFooter').style.display = '';
+    updatePlChapterOptions();
 }
 
 function hidePlaylist() {
@@ -917,6 +1009,10 @@ async function doPlaylistDownload() {
             formatId: formatId,
             extractAudio: isAudio,
             audioFormat: isAudio ? opt.dataset.format || 'mp3' : undefined,
+            duration: item.duration || null,
+            // OGG/vorbis and WAV don't support embedded chapters; only mp3/m4a/opus do.
+            embedChapters: playlistChapters.embed && !(isAudio && ['vorbis', 'wav'].includes(opt.dataset.format)),
+            splitChapters: playlistChapters.split,
         }));
 
         await window.api.queueAdd(queueItems);
@@ -967,14 +1063,12 @@ function renderQueue() {
         statusParts.push(`${counts.downloading} downloading`);
     }
     if (counts.pending > 0) statusParts.push(`${counts.pending} waiting`);
-    if (counts.completed > 0) statusParts.push(`${counts.completed} done`);
     if (counts.failed > 0) statusParts.push(`${counts.failed} failed`);
     $queueStatus.textContent = statusParts.join(' · ') || '0 items';
 
     // Show/hide action buttons
     $qCancelAllBtn.style.display = isActive ? 'inline-block' : 'none';
     $qRetryFailedBtn.style.display = counts.failed > 0 ? 'inline-block' : 'none';
-    $qClearDoneBtn.style.display = counts.completed > 0 || (counts.failed > 0 && !isActive) ? 'inline-block' : 'none';
 
     // Render items
     $queueItems.innerHTML = items.map((item) => queueItemHTML(item)).join('');
@@ -993,18 +1087,44 @@ function queueItemHTML(item) {
         statusHTML = '<span class="q-item-status waiting">Waiting...</span>';
         actionsHTML = `<button class="q-item-remove" data-id="${item.id}" title="Remove">×</button>`;
     } else if (item.state === 'downloading') {
+        const phase = item.progress?.phase || 'download';
+        const ppStep = item.progress?.ppStep || '';
         const pct = item.progress?.percent || '0%';
-        const speed = item.progress?.speed || '';
-        const eta = item.progress?.eta || '';
         const pctNum = parseFloat(pct) || 0;
-        const detail = [speed, eta ? 'ETA ' + eta : ''].filter(Boolean).join(' · ');
 
-        statusHTML = `<span class="q-item-status downloading">${pct}${detail ? ' · ' + detail : ''}</span>`;
-        progressHTML = `<div class="q-item-progress-track"><div class="q-item-progress-fill" style="width:${pctNum}%"></div></div>`;
+        // yt-dlp prints no progress once the file hits 100%, but the merge
+        // and encode steps are still running. We track ffmpeg's -progress file
+        // in the main process, which gives a real percentage for encode phases.
+        let status;
+        let barClass = '';
+        let barWidth = pctNum;
+        if (phase === 'processing') {
+            const encodePct = item.progress?.encodePct;
+            if (typeof encodePct === 'number' && encodePct >= 0) {
+                status = 'Encoding' + (ppStep ? ' · ' + ppStep : '') + ' · ' + encodePct + '%';
+                barClass = '';
+                barWidth = encodePct;
+            } else {
+                status = 'Encoding' + (ppStep ? ' · ' + ppStep : '');
+                barClass = 'full striped';
+                barWidth = 100;
+            }
+        } else if (phase === 'cleanup') {
+            status = 'Cleaning up...';
+            barClass = 'full striped';
+            barWidth = 100;
+        } else {
+            const details = [Math.round(pctNum) + '%'];
+            const speedTxt = cleanSpeed(item.progress?.speed || '');
+            if (speedTxt) details.push(speedTxt);
+            const etaTxt = cleanEta(item.progress?.eta || '');
+            if (etaTxt) details.push('ETA ' + etaTxt);
+            status = 'Downloading · ' + details.join(' · ');
+        }
+
+        statusHTML = `<span class="q-item-status downloading">${status}</span>`;
+        progressHTML = `<div class="q-item-progress-track"><div class="q-item-progress-fill ${barClass}" style="width:${barWidth}%"></div></div>`;
         actionsHTML = `<button class="q-item-cancel" title="Skip this item">⏭</button>`;
-    } else if (item.state === 'completed') {
-        statusHTML = '<span class="q-item-status completed">Complete ✓</span>';
-        actionsHTML = `<button class="q-item-open-folder" title="Open folder" onclick="doOpenFolder()">📂</button><button class="q-item-remove" data-id="${item.id}" title="Remove">×</button>`;
     } else if (item.state === 'failed') {
         const errText = escapeHtml(item.error || 'Failed');
         statusHTML = `<span class="q-item-status failed" title="${errText}">${errText}</span>`;
@@ -1097,15 +1217,6 @@ async function doRetryFailed() {
         addLog('Retrying failed items...', 'highlight');
     } catch (e) {
         addLog('Retry failed: ' + e.message, 'error');
-    }
-}
-
-async function doClearCompleted() {
-    try {
-        await window.api.queueClearCompleted();
-        addLog('Cleared completed items');
-    } catch (e) {
-        addLog('Clear failed: ' + e.message, 'error');
     }
 }
 
@@ -1357,6 +1468,7 @@ function loadFromHistory(idx) {
     videoInfo = entry.info;
     presets = entry.presets;
     selectedPreset = null;
+    selectedChapters = { embed: false, split: false };
     isPlaylistMode = false;
     activeFetchId = null;
 


### PR DESCRIPTION
## Summary

Fixes and cleanup around post-processing, chapter splits, OGG downloads, and the queue.

## Changes

- **Real encode progress**: merge, extract, and convert now read ffmpeg's `-progress` file and report actual percentage against media duration. Remux, embed, split, and cleanup use the indeterminate bar.
- **Chapter split cleanup**: delete the redundant full file yt-dlp leaves behind when `--split-chapters` finishes writing the chapter files.
- **OGG fix**: the preset sent `audio-format ogg`, which yt-dlp rejects. Now sends `vorbis`. Chapter embed/split options hidden for OGG and WAV since those containers can't hold chapter metadata.
- **Queue behavior**:
  - Completed downloads auto-remove from the queue; history still keeps them.
  - "Done" toast uses run counters instead of stale state.
  - "Downloading X/Y" stays correct whether items complete or fail.
  - Removed the now-redundant "Clear done" button and `queue:clearCompleted` plumbing.
- **Progress parsing fix**: yt-dlp speeds can contain spaces (e.g. `Unknown B/s`), which shifted the whitespace-split columns and corrupted the ETA. DLPROG is now pipe-delimited.
- **Spawn cleanup**: replaced the `_proc` polling handoff with an explicit `onSpawn` callback; temp progress file is cleaned up when yt-dlp fails to spawn.
- **Cleanup**: removed dead CSS.

## Housekeeping

- `package.json`: `allowScripts` pins `electron` and `ffmpeg-static` postinstall scripts, which npm 12 blocks by default.
- `.gitignore`: ignore stray media downloads (`.ogg`/`.m4a`) at the repo root.